### PR TITLE
Add future picking support - fixes #1

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -53,6 +53,22 @@ class HomeScreen extends StatelessWidget {
             ElevatedButton(
               onPressed: () {
                 Navigator.of(context).push(MaterialPageRoute(
+                  builder: (context) => const IntoFuture(),
+                ));
+              },
+              child: const Text("Future"),
+            ),
+            ElevatedButton(
+              onPressed: () {
+                Navigator.of(context).push(MaterialPageRoute(
+                  builder: (context) => const IntoFutureWithDates(),
+                ));
+              },
+              child: const Text("Future w/Dates"),
+            ),
+            ElevatedButton(
+              onPressed: () {
+                Navigator.of(context).push(MaterialPageRoute(
                   builder: (context) => const Customized(),
                 ));
               },
@@ -60,6 +76,88 @@ class HomeScreen extends StatelessWidget {
             ),
           ],
         ),
+      ),
+    );
+  }
+}
+
+
+class IntoFutureWithDates extends StatelessWidget {
+  const IntoFutureWithDates({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final today = DateTime.now();
+    final twoYearsFromNow = today.add(const Duration(days: 365*2));
+    return Scaffold(
+      appBar: AppBar(
+        title: ValueListenableBuilder(
+            valueListenable: darkThemeNotifier,
+            builder: (context, value, _) {
+              return Text("Future- ${value ? "Dark mode" : "Light mode"}");
+            }),
+        actions: [
+          ValueListenableBuilder(
+              valueListenable: darkThemeNotifier,
+              builder: (context, value, _) {
+                return IconButton(
+                  onPressed: () {
+                    darkThemeNotifier.value = !darkThemeNotifier.value;
+                  },
+                  icon: Icon(
+                    value ? Icons.dark_mode : Icons.light_mode,
+                  ),
+                );
+              })
+        ],
+      ),
+      body: ScrollableDateRangePicker(
+        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 10),
+        onDateRangeSelect: (startDate, endDate) {
+          debugPrint('onDateRangeSelect() start: $startDate  end: $endDate');
+        },
+        calendarStartDate: today,
+        calendarEndDate: twoYearsFromNow,
+        isFixedTopWeekDayHeader : false,
+
+      ),
+    );
+  }
+}
+
+class IntoFuture extends StatelessWidget {
+  const IntoFuture({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: ValueListenableBuilder(
+            valueListenable: darkThemeNotifier,
+            builder: (context, value, _) {
+              return Text("Future- ${value ? "Dark mode" : "Light mode"}");
+            }),
+        actions: [
+          ValueListenableBuilder(
+              valueListenable: darkThemeNotifier,
+              builder: (context, value, _) {
+                return IconButton(
+                  onPressed: () {
+                    darkThemeNotifier.value = !darkThemeNotifier.value;
+                  },
+                  icon: Icon(
+                    value ? Icons.dark_mode : Icons.light_mode,
+                  ),
+                );
+              })
+        ],
+      ),
+      body: ScrollableDateRangePicker(
+        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 10),
+        onDateRangeSelect: (startDate, endDate) {
+          debugPrint('onDateRangeSelect() start: $startDate  end: $endDate');
+        },
+        pickerGoesIntoFuture: true,
       ),
     );
   }
@@ -94,7 +192,9 @@ class Default extends StatelessWidget {
       ),
       body: ScrollableDateRangePicker(
         padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 10),
-        onDateRangeSelect: (startDate, endDate) {},
+        onDateRangeSelect: (startDate, endDate) {
+          debugPrint('onDateRangeSelect() start: $startDate  end: $endDate');
+        },
       ),
     );
   }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -53,6 +53,14 @@ class HomeScreen extends StatelessWidget {
             ElevatedButton(
               onPressed: () {
                 Navigator.of(context).push(MaterialPageRoute(
+                  builder: (context) => const Default(goIntoPastScrollingDown:false),
+                ));
+              },
+              child: const Text("Default Reversed"),
+            ),
+            ElevatedButton(
+              onPressed: () {
+                Navigator.of(context).push(MaterialPageRoute(
                   builder: (context) => const IntoFuture(),
                 ));
               },
@@ -94,7 +102,7 @@ class IntoFutureWithDates extends StatelessWidget {
         title: ValueListenableBuilder(
             valueListenable: darkThemeNotifier,
             builder: (context, value, _) {
-              return Text("Future- ${value ? "Dark mode" : "Light mode"}");
+              return Text("Dates- ${value ? "Dark mode" : "Light mode"}");
             }),
         actions: [
           ValueListenableBuilder(
@@ -164,7 +172,9 @@ class IntoFuture extends StatelessWidget {
 }
 
 class Default extends StatelessWidget {
-  const Default({super.key});
+  const Default({super.key, this.goIntoPastScrollingDown=true});
+
+  final bool goIntoPastScrollingDown;
 
   @override
   Widget build(BuildContext context) {
@@ -173,7 +183,7 @@ class Default extends StatelessWidget {
         title: ValueListenableBuilder(
             valueListenable: darkThemeNotifier,
             builder: (context, value, _) {
-              return Text("Default- ${value ? "Dark mode" : "Light mode"}");
+              return Text("Default ${goIntoPastScrollingDown?'':'(Past Up)'}- ${value ? "Dark mode" : "Light mode"}");
             }),
         actions: [
           ValueListenableBuilder(
@@ -195,6 +205,7 @@ class Default extends StatelessWidget {
         onDateRangeSelect: (startDate, endDate) {
           debugPrint('onDateRangeSelect() start: $startDate  end: $endDate');
         },
+        datesIncreaseScrollingDown: !goIntoPastScrollingDown,
       ),
     );
   }

--- a/lib/src/scrollable_date_range_picker_widget.dart
+++ b/lib/src/scrollable_date_range_picker_widget.dart
@@ -81,6 +81,9 @@ class ScrollableDateRangePicker extends StatefulWidget {
   /// [isFixedTopWeekDayHeader]
   final bool isFixedTopWeekDayHeader;
 
+  /// A boolean that determines if the picker goes into the future vs the past
+  final bool? pickerGoesIntoFuture;
+
   const ScrollableDateRangePicker({
     super.key,
     required this.onDateRangeSelect,
@@ -101,7 +104,8 @@ class ScrollableDateRangePicker extends StatefulWidget {
     this.calendarEndDate,
     this.isFixedTopWeekDayHeader = true,
     this.disabledDaysTextStyle,
-  });
+    this.pickerGoesIntoFuture,
+  }) : assert( pickerGoesIntoFuture==null || (calendarStartDate==null && calendarEndDate==null) );
 
   @override
   State<ScrollableDateRangePicker> createState() =>
@@ -112,6 +116,46 @@ class _ScrollableDateRangePickerState extends State<ScrollableDateRangePicker> {
   DateTime today = DateTime.now();
   DateTime? firstDate;
   DateTime? lastDate;
+  late final bool datesGoIntoPast;
+  late final int? knownMonthSpan;
+
+  static int getMonthSizeBetweenDates(DateTime initialDate, DateTime endDate){
+    return (endDate.year-initialDate.year)*12+(endDate.month-initialDate.month)+1;
+  }
+
+  @override
+  void initState() {
+    super.initState();
+
+    debugPrint('Entering initState()');
+
+    bool intoFuture = false;
+    int? computedMonthSpan;
+    final today = DateTime.now();
+
+    if(widget.pickerGoesIntoFuture!=null) {
+      intoFuture = widget.pickerGoesIntoFuture!;
+    } else if(widget.calendarEndDate!=null && widget.calendarStartDate!=null) {
+      if(widget.calendarStartDate!.isBefore(today) && widget.calendarEndDate!.isAfter(today) &&
+              widget.calendarStartDate!.month!=today.month && widget.calendarEndDate!.month!=today.month &&
+              widget.calendarStartDate!.year!=today.year && widget.calendarEndDate!.year!=today.year) {
+        // THROW because picker cannot span future and past
+        throw Exception('ScrollableDateRangePicker() does not support displaying months in past and future simultaneously.');
+      }
+
+      print("Computing span from ${widget.calendarStartDate} to ${widget.calendarEndDate}");
+      intoFuture = widget.calendarEndDate!.isAfter(widget.calendarStartDate!);
+      computedMonthSpan =  intoFuture ?
+                          getMonthSizeBetweenDates( widget.calendarStartDate!, widget.calendarEndDate!)
+                          :
+                          getMonthSizeBetweenDates( widget.calendarEndDate!, widget.calendarStartDate!);
+      debugPrint("Month span = $computedMonthSpan");
+    }
+    datesGoIntoPast = !intoFuture;
+    knownMonthSpan = computedMonthSpan;
+    debugPrint('Leaving initState() datesGoIntoPast=$datesGoIntoPast knownMonthSpan=$knownMonthSpan');
+
+  }
 
   List<DateTime?> _generateDaysInMonth(DateTime currentMonth) {
     List<DateTime?> allDaysInMonth = [];
@@ -310,8 +354,11 @@ class _ScrollableDateRangePickerState extends State<ScrollableDateRangePicker> {
           if (widget.isFixedTopWeekDayHeader) _buildDaysOfWeek(),
           Expanded(
             child: ListView.builder(
+              itemCount: knownMonthSpan,
+              reverse: datesGoIntoPast,
               itemBuilder: (context, index) {
-                return _buildDaysGrid(DateTime(today.year, today.month - index));
+                return _buildDaysGrid(DateTime(today.year, datesGoIntoPast ? 
+                                      (today.month - index) : (today.month + index) ));
               },
             ),
           ),


### PR DESCRIPTION
This PR adds future picking support - ie,. the months presented to the user are in the future instead of the past.

There are two ways to accomplish this - provide a start/end date via `calendarStartDate` and `calendarEndDate` that are today or after today - or to specifiy `pickerGoesIntoFuture` as true (this allows for same behavior as current picker (but for future dates instead of past dates)).

There are some simple asserts to make sure that the BOTH start/end dates and pickerGoesIntoFuture are not both provided in the constructor.
There is also a check in initState() to make sure that the  start/end dates do not create a span of past and future months, as the picker can only (currently) support going into the past or the future, not both.  (The use of ListView.builder() does not easily allow for starting at a arbitrary indices in the middle of a (potentially infinite) list.)

I have a tiny bit of cleanup but it will be ready shortly.
